### PR TITLE
Adding BASE_DIR import when using 'theme'

### DIFF
--- a/config/settings/sample.local.py
+++ b/config/settings/sample.local.py
@@ -1,3 +1,6 @@
+import os
+from . import BASE_DIR
+
 '''
 Debug mode, don't use this in production
 '''


### PR DESCRIPTION
relates to #1 

Using the ```config/settings/local.py```  being generated from ```config/settings/sample.local.py``` the app will not find start and crashes when having uncommented 
```python
THEME_DIR = os.path.join(BASE_DIR, 'theme')
```
The reason is that ```BASE_DIR``` is not defined because we also must import it in the first place via
```python
import os
from . import BASE_DIR
```