### PR TITLE
Pin psycopg2-binary to the last version compatible with Django 2.2.x

### DIFF
--- a/requirements/postgres.txt
+++ b/requirements/postgres.txt
@@ -1,1 +1,1 @@
-psycopg2-binary>=2.8
+psycopg2-binary>=2.8,<2.9


### PR DESCRIPTION
Django versions below 3.1 are not compatible with psycopg2(-binary)>=2.9 (see https://github.com/psycopg/psycopg2/issues/1293) and this has been confirmed to stay this way (see https://github.com/django/django/pull/14530). 

This PR pins the psycopg2 requirements for postgres databases to the compatible version, resolving https://github.com/rdmorganiser/rdmo/issues/351. The <2.9 requirement can be removed, once rdmo uses Django>=3.1. 

