### PR TITLE
Debug toolbar

### DIFF
--- a/config/settings/__init__.py
+++ b/config/settings/__init__.py
@@ -45,3 +45,12 @@ if DEBUG:
         'rest_framework.renderers.JSONRenderer',
         'rest_framework.renderers.BrowsableAPIRenderer',
     )
+
+# enable debug toolbar
+try:
+    if DEBUG and DEBUG_TOOLBAR:
+        INSTALLED_APPS += ['debug_toolbar']
+        MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE
+        INTERNAL_IPS = ['127.0.0.1']
+except NameError:
+    DEBUG_TOOLBAR = False

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,3 +1,4 @@
+import debug_toolbar
 from django.contrib import admin
 from django.urls import include, path
 
@@ -12,6 +13,7 @@ urlpatterns = [
     path('api/v1/', include('rdmo.core.urls.swagger')),
 
     path('admin/', admin.site.urls),
+    path('__debug__/', include(debug_toolbar.urls)),
 ]
 
 handler400 = 'rdmo.core.views.bad_request'

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,4 +1,4 @@
-import debug_toolbar
+from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 
@@ -12,9 +12,12 @@ urlpatterns = [
     path('api/v1/', include('rdmo.core.urls.v1')),
     path('api/v1/', include('rdmo.core.urls.swagger')),
 
-    path('admin/', admin.site.urls),
-    path('__debug__/', include(debug_toolbar.urls)),
+    path('admin/', admin.site.urls)
 ]
+
+if settings.DEBUG_TOOLBAR:
+    import debug_toolbar
+    urlpatterns += [path('__debug__/', include(debug_toolbar.urls))]
 
 handler400 = 'rdmo.core.views.bad_request'
 handler403 = 'rdmo.core.views.forbidden'

--- a/requirements/debug.txt
+++ b/requirements/debug.txt
@@ -1,0 +1,1 @@
+django-debug-toolbar


### PR DESCRIPTION
Add support for the [django-debug-toolbar](https://django-debug-toolbar.readthedocs.io/en/latest/), but only if installed.